### PR TITLE
add Reexport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "b63598f2-4201-4681-96ef-5c56482a8c99"
 authors = ["blueqat inc."]
 version = "0.1.0"
 
+[deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
 [compat]
 julia = "1"
 


### PR DESCRIPTION
This PR adds `Reexport` module as a dependency to suppress the following error 

```
julia> using blueqat
[ Info: Precompiling blueqat [b63598f2-4201-4681-96ef-5c56482a8c99]
ERROR: LoadError: LoadError: LoadError: LoadError: ArgumentError: Package blueqat does not have Reexport in its dependencies:
- If you have blueqat checked out for development and have
  added Reexport as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with blueqat
...
```